### PR TITLE
Fix unportable type for ARM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.1.8"
 
 [dependencies]
 num = "*"
-libc = "0.2"
+libc = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.1.8"
 
 [dependencies]
 num = "*"
-libc = "0.1"
+libc = "0.2"

--- a/src/linux/langinfo.rs
+++ b/src/linux/langinfo.rs
@@ -41,7 +41,7 @@ unsafe fn decode_strings<'a>(mut ptr: *const ::libc::c_char, iconv: Option<&ICon
     return res;
 }
 
-unsafe fn decode_bytes<'a>(ptr: *const ::libc::c_char) -> &'a [i8] {
+unsafe fn decode_bytes<'a>(ptr: *const ::libc::c_char) -> &'a [::libc::c_char] {
     if ptr.is_null() {
         &[]
     } else {
@@ -404,9 +404,9 @@ enum ByteItems {
 }
 
 impl<'a> LanginfoItem<'a> for ByteItems {
-    type Type = i8;
+    type Type = ::libc::c_char;
     fn needs_iconv() -> Option<CodesetItems> { None }
-    unsafe fn decode(&self, ptr: *const ::libc::c_char, _: Option<&IConv>) -> i8 {
+    unsafe fn decode(&self, ptr: *const ::libc::c_char, _: Option<&IConv>) -> ::libc::c_char {
         *ptr
     }
     fn to_ffi(self) -> ffi::nl_item { self as ffi::nl_item }
@@ -425,9 +425,9 @@ enum ByteArrayItems {
 }
 
 impl<'a> LanginfoItem<'a> for ByteArrayItems {
-    type Type = &'a [i8];
+    type Type = &'a [::libc::c_char];
     fn needs_iconv() -> Option<CodesetItems> { None }
-    unsafe fn decode(&self, ptr: *const ::libc::c_char, _: Option<&IConv>) -> &'a [i8] {
+    unsafe fn decode(&self, ptr: *const ::libc::c_char, _: Option<&IConv>) -> &'a [::libc::c_char] {
         decode_bytes(ptr)
     }
     fn to_ffi(self) -> ffi::nl_item { self as ffi::nl_item }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -126,9 +126,9 @@ impl IConv {
     /// with in Rust.
     pub fn convert(&self, src: &[u8], dst: &mut [u8]) -> (isize, usize, usize) {
         let mut inptr: *const ::libc::c_char = src.as_ptr() as *const ::libc::c_char;
-        let mut insize: ::libc::size_t = src.len() as ::libc::size_t;
+        let mut insize = src.len() as ffi::size_t ;
         let mut outptr: *mut ::libc::c_char = dst.as_ptr() as *mut ::libc::c_char;
-        let mut outsize: ::libc::size_t = dst.len() as ::libc::size_t;
+        let mut outsize = dst.len() as ffi::size_t;
         // XXX: Do we need error handling? We don't expect errors and can't do much about them here.
         let res = unsafe {
             ffi::iconv(self.iconv,


### PR DESCRIPTION
I've tested this patch on my cubieboard and FreeBSD laptop. With libc 0.2 which has fixed ARM issue, it can run well on ARM, and it can also run well with libc 0.1 on a amd64 machine.
