### PR TITLE
Access to collation and equivalence classes

### DIFF
--- a/examples/localeinfo.rs
+++ b/examples/localeinfo.rs
@@ -225,6 +225,10 @@ pub fn main() {
     show(&f, langinfo::_NL_IDENTIFICATION_REVISION);
     show(&f, langinfo::_NL_IDENTIFICATION_DATE);
     show(&f, langinfo::_NL_IDENTIFICATION_CATEGORY);
+    show(&f, langinfo::_NL_COLLATE_TABLEMB);
+    show(&f, langinfo::_NL_COLLATE_WEIGHTMB);
+    show(&f, langinfo::_NL_COLLATE_EXTRAMB);
+    show(&f, langinfo::_NL_COLLATE_INDIRECTMB);
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/linux/langinfo.rs
+++ b/src/linux/langinfo.rs
@@ -443,6 +443,10 @@ pub use self::ByteArrayItems::*;
 pub enum IntegralItems {
     // Collate
     _NL_COLLATE_NRULES = ffi::_NL_COLLATE_NRULES as isize,
+    _NL_COLLATE_TABLEMB = ffi::_NL_COLLATE_TABLEMB as isize,
+    _NL_COLLATE_WEIGHTMB = ffi::_NL_COLLATE_WEIGHTMB as isize,
+    _NL_COLLATE_EXTRAMB = ffi::_NL_COLLATE_EXTRAMB as isize,
+    _NL_COLLATE_INDIRECTMB = ffi::_NL_COLLATE_INDIRECTMB as isize, 
     _NL_COLLATE_SYMB_HASH_SIZEMB = ffi::_NL_COLLATE_SYMB_HASH_SIZEMB as isize,
     // CType
     _NL_CTYPE_MB_CUR_MAX = ffi::_NL_CTYPE_MB_CUR_MAX as isize,


### PR DESCRIPTION
Trying to add equivalence support for rust regexp

https://github.com/rust-lang/regex/issues/404

I found your crate. I'm little lost into rust and locale support (i18n, l10n,l20n) so hope yours is the right place

This is only a WIP to trying to retrieve equivalence characters from locale

get_equivalence('0') should return ['o','ò', 'ó', 'ö']. 

All that info is in libc localedata

[link to code on glibc](https://sourceware.org/git/?p=glibc.git;a=blob;f=posix/regcomp.c;h=871ae2ffab5ffc57a9d3b594c42feec5cdd5a4f6;hb=HEAD#l3427)

[link to doc](http://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap07.html#tag_07_03_02_04)