### PR TITLE
Bug fix for long day names.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "locale"
-version = "0.2.3-pre"
+version = "0.2.4-pre"
 description = "Library for basic localisation. Warning: Major rewrite pending for 0.3!"
 authors = [
     "Ben S <ogham@bsago.me>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ impl Time {
     }
 
     pub fn long_day_name(&self, days_from_sunday: usize) -> String {
-        self.day_names[days_from_sunday].clone()
+        self.long_day_names[days_from_sunday].clone()
     }
 
     pub fn short_day_name(&self, days_from_sunday: usize) -> String {


### PR DESCRIPTION
There is a bug in `long_day_names` that uses the wrong array for displaying the day names.  This PR fixes this and updates the patch version number.